### PR TITLE
Add git to php cli image

### DIFF
--- a/php/cli/Dockerfile
+++ b/php/cli/Dockerfile
@@ -3,9 +3,11 @@ FROM srijanlabs/php:${PHP_VERSION}-1.x
 
 ENV PHP_MEMORY_LIMIT=256M
 
-RUN curl -sS https://getcomposer.org/installer | php && \
-    mv composer.phar /usr/local/bin/composer && \
-    chmod +x /usr/local/bin/composer
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/composer \
+    && chmod +x /usr/local/bin/composer
 
 USER continua
 


### PR DESCRIPTION
This fixes issue that prevents the composer from applying patches as it depends on git binary
Fix: https://github.com/srijanone/docker-base-images/issues/16