### PR TITLE
Blackfire integration

### DIFF
--- a/php/dev/Dockerfile
+++ b/php/dev/Dockerfile
@@ -12,7 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     php${PHP_VERSION}-xdebug \
     && PHP_VERISON=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
-    && curl -sSL -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s "https://blackfire.io/api/v1/releases/probe/php/alpine/amd64/$PHP_VERISON" \
+    && curl -sSL -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s "https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$PHP_VERISON" \
     && mkdir -p /tmp/blackfire \
     && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \

--- a/php/dev/Dockerfile
+++ b/php/dev/Dockerfile
@@ -18,8 +18,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
-COPY conf.d/01_blackfire.ini /etc/php/conf.d/01_blackfire.ini
-COPY conf.d/50_dev.ini /etc/php/conf.d/50_dev.ini
-COPY conf.d/01_xdebug.ini /etc/php/conf.d/01_xdebug.ini
+COPY conf.d/01_blackfire.ini /etc/php/${PHP_VERSION}/fpm/conf.d/01_blackfire.ini
+COPY conf.d/50_dev.ini /etc/php/${PHP_VERSION}/fpm/conf.d/50_dev.ini
+COPY conf.d/01_xdebug.ini /etc/php/${PHP_VERSION}/fpm/conf.d/01_xdebug.ini
 
 USER continua

--- a/php/dev/conf.d/01_blackfire.ini
+++ b/php/dev/conf.d/01_blackfire.ini
@@ -1,4 +1,4 @@
 extension=blackfire.so
-blackfire.agent_socket=tcp://127.0.0.1:8707
+blackfire.agent_socket=tcp://blackfire:8707
 blackfire.log_level = 4
 blackfire.log_file = /tmp/blackfire.log

--- a/php/dev/conf.d/01_xdebug.ini
+++ b/php/dev/conf.d/01_xdebug.ini
@@ -1,7 +1,9 @@
 zend_extension=xdebug.so
-xdebug.max_nesting_level=256 ; Fixes debugging for D8.
 xdebug.remote_enable=1
+xdebug.remote_autostart=1
+xdebug.remote_connect_back=0
+xdebug.remote_host=host.docker.internal
+xdebug.remote_port=9001
 xdebug.remote_handler=dbgp
 xdebug.remote_mode=req
-xdebug.remote_port=9000
-xdebug.remote_connect_back=0
+xdebug.max_nesting_level=1500


### PR DESCRIPTION
@AshishThakur  Changes for Xdebug is also visible here as the PR is open. I check out this branch from my fork which is updated. I am not resolving this as of now.

For backfire to be working I need to change in Dockerfile as well. Earlier it was an alpine version of backfire. 

Apart from this, I have opened another PR with vega for starter kit docker-compose file changes.

Please review.