### PR TITLE
Add php-fpm-apache image

### DIFF
--- a/php-fpm-apache/Dockerfile
+++ b/php-fpm-apache/Dockerfile
@@ -1,0 +1,34 @@
+ARG PHP_TAG
+FROM srijanlabs/php-fpm:${PHP_TAG}
+
+USER root
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apache2=2.4.38-3+deb10u3 \
+        libapache2-mod-fcgid=1:2.3.9-4 \
+    && a2enmod actions \
+    && a2enmod proxy \
+    && a2enmod rewrite \
+    && a2enmod proxy_fcgi \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY start.sh /usr/local/bin/start.sh
+
+# Apache configurations
+COPY app.conf /etc/apache2/sites-enabled/000-default.conf
+COPY envvars ports.conf /etc/apache2/
+
+EXPOSE 8080
+
+ENV DOC_ROOT="/app/web" \
+    PHP_HOST=localhost
+
+RUN chmod -R 0777 /var/tmp \
+    && chown -R continua:continua \
+        /var/log \
+        /var/lib/apache2 \
+        /etc/apache2
+
+USER continua
+
+CMD [ "start.sh" ]

--- a/php-fpm-apache/Makefile
+++ b/php-fpm-apache/Makefile
@@ -1,0 +1,26 @@
+#!/usr/bin/make -f
+
+REGISTRY=srijanlabs/php-fpm-apache
+define build_image
+	docker build --no-cache --build-arg PHP_TAG=${1} -t $(REGISTRY):${1} .
+	docker build --no-cache --build-arg PHP_TAG=${1}-dev -t $(REGISTRY):${1}-dev .
+endef
+
+define push_image
+	# Pushing production images.
+	docker push $(REGISTRY):${1}
+	docker push $(REGISTRY):${1}-dev 
+
+endef
+
+build:
+	$(call build_image,7.2-1.x)
+	$(call build_image,7.3-1.x)
+	$(call build_image,7.4-1.x)
+
+push:
+	$(call push_image,7.2-1.x)
+	$(call push_image,7.3-1.x)
+	$(call push_image,7.4-1.x)
+
+.PHONY: *

--- a/php-fpm-apache/app.conf
+++ b/php-fpm-apache/app.conf
@@ -1,0 +1,13 @@
+LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+<VirtualHost *:8080>
+  DocumentRoot ${DOC_ROOT}
+  ErrorLog /dev/stderr
+  TransferLog /dev/stdout
+  ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://${PHP_HOST}:9000/app/web/$1
+  <Directory  ${DOC_ROOT}>
+    Options Indexes FollowSymLinks
+    AllowOverride All
+    Require all granted
+    DirectoryIndex index.php
+  </Directory>
+</VirtualHost>

--- a/php-fpm-apache/envvars
+++ b/php-fpm-apache/envvars
@@ -1,0 +1,47 @@
+# envvars - default environment variables for apache2ctl
+
+# this won't be correct after changing uid
+unset HOME
+
+# for supporting multiple apache2 instances
+if [ "${APACHE_CONFDIR##/etc/apache2-}" != "${APACHE_CONFDIR}" ] ; then
+	SUFFIX="-${APACHE_CONFDIR##/etc/apache2-}"
+else
+	SUFFIX=
+fi
+
+# Since there is no sane way to get the parsed apache2 config in scripts, some
+# settings are defined via environment variables and then used in apache2ctl,
+# /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
+export APACHE_RUN_USER=continua
+export APACHE_RUN_GROUP=continua
+# temporary state file location. This might be changed to /run in Wheezy+1
+export APACHE_PID_FILE=/var/run/apache2$SUFFIX/apache2.pid
+export APACHE_RUN_DIR=/var/run/apache2$SUFFIX
+export APACHE_LOCK_DIR=/var/lock/apache2$SUFFIX
+# Only /var/log/apache2 is handled by /etc/logrotate.d/apache2.
+export APACHE_LOG_DIR=/var/log/apache2$SUFFIX
+
+## The locale used by some modules like mod_dav
+export LANG=C
+## Uncomment the following line to use the system default locale instead:
+#. /etc/default/locale
+
+export LANG
+
+## The command to get the status for 'apache2ctl status'.
+## Some packages providing 'www-browser' need '--dump' instead of '-dump'.
+#export APACHE_LYNX='www-browser -dump'
+
+## If you need a higher file descriptor limit, uncomment and adjust the
+## following line (default is 8192):
+#APACHE_ULIMIT_MAX_FILES='ulimit -n 65536'
+
+## If you would like to pass arguments to the web server, add them below
+## to the APACHE_ARGUMENTS environment.
+#export APACHE_ARGUMENTS=''
+
+## Enable the debug mode for maintainer scripts.
+## This will produce a verbose output on package installations of web server modules and web application
+## installations which interact with Apache
+#export APACHE2_MAINTSCRIPT_DEBUG=1

--- a/php-fpm-apache/ports.conf
+++ b/php-fpm-apache/ports.conf
@@ -1,0 +1,15 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen 8080
+
+<IfModule ssl_module>
+        Listen 443
+</IfModule>
+
+<IfModule mod_gnutls.c>
+        Listen 443
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/php-fpm-apache/start.sh
+++ b/php-fpm-apache/start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Start the first process
+# ./my_first_process -D
+php-fpm -F &
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Failed to start php-fpm : $status"
+  exit $status
+fi
+
+# Start the second process
+# ./my_second_process -D
+apache2ctl -D FOREGROUND &
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Failed to start apache2 : $status"
+  exit $status
+fi
+
+# Naive check runs checks once a minute to see if either of the processes exited.
+# This illustrates part of the heavy lifting you need to do if you want to run
+# more than one service in a container. The container exits with an error
+# if it detects that either of the processes has exited.
+# Otherwise it loops forever, waking up every 60 seconds
+
+while sleep 15; do
+  # If the greps find anything, they exit with 0 status
+  # If they are not both 0, then something is wrong
+  ps aux |grep php-fpm|grep -q -v grep
+  if [ $? -ne 0 ]; then
+    echo "php-fpm has already exited."
+    exit 1
+  fi
+  ps aux |grep apache |grep -q -v grep
+  if [ $? -ne 0 ]; then
+    echo "apache has already exited."
+    exit 1
+  fi
+done

--- a/php/Makefile
+++ b/php/Makefile
@@ -10,7 +10,6 @@ define build_image
 
 	# Building dev images.
 	docker build --no-cache --build-arg PHP_VERSION=${1} --build-arg IMAGE=$(REGISTRY)-fpm:${1}-1.x -t $(REGISTRY)-fpm:${1}-1.x-dev dev
-	docker build --no-cache --build-arg PHP_VERSION=${1} --build-arg IMAGE=$(REGISTRY)-cli:${1}-1.x -t $(REGISTRY)-cli:${1}-1.x-dev dev
 
 endef
 


### PR DESCRIPTION
Build a single image using the base containing php-fpm and apache.

Default CMD will start both php-fpm and apache on the same container.
### Commands to run individual containers:
|   Application  |                   command                 |
|--------------|:-------------------------------:|
|  apache         |  apache2ctl -D FOREGROUND  | 
|  php-fpm       |   php-fpm -F                              |