### PR TITLE
Correction in PHP_INI_SCAN_DIR variable as it is causing issue in cli build image.

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -10,57 +10,94 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
     # debian
     - name: Build debian image
-      run: docker build -f base/Dockerfile -t srijanlabs/debian:latest .
+      id: build_debian
+      run: docker build -f base/debian/Dockerfile -t srijanlabs/debian:latest base/debian
     - name: Scan debian image
+      id: scan_debian
       uses: anchore/scan-action@master
       with:
         image-reference: "srijanlabs/debian:latest"
-        dockerfile-path: "base/Dockerfile"
-        fail-build: true
+        dockerfile-path: "base/debian/Dockerfile"
+        fail-build: false
+        acs-report-enable: true
+
     # apache
     - name: Build apache image
-      run: docker build -f apache/Dockerfile -t srijanlabs/apache:latest apache
+      id: build_apache
+      run: docker build -f apache/debian/Dockerfile -t srijanlabs/apache:latest apache/debian
     - name: Scan apache image
+      id: scan_apache
       uses: anchore/scan-action@master
       with:
         image-reference: "srijanlabs/apache:latest"
-        dockerfile-path: "apache/Dockerfile"
-        fail-build: true
+        dockerfile-path: "apache/debian/Dockerfile"
+        fail-build: false
+        acs-report-enable: true
+
     # php-base
     - name: Build php image
-      run: docker build -f php/base/Dockerfile -t srijanlabs/php:latest php/base
+      id: build_php
+      run: docker build -f php/debian/base/Dockerfile -t srijanlabs/php:latest php/debian/base
     - name: Scan php image
+      id: scan_php
       uses: anchore/scan-action@master
       with:
         image-reference: "srijanlabs/php:latest"
-        dockerfile-path: "php/base/Dockerfile"
-        fail-build: true
+        dockerfile-path: "php/debian/base/Dockerfile"
+        fail-build: false
+        acs-report-enable: true
+
     # php-cli
     - name: Build php-cli image
-      run: docker build -f php/cli/Dockerfile -t srijanlabs/php-cli:latest php/cli
+      id: build_php_cli
+      run: docker build -f php/debian/cli/Dockerfile -t srijanlabs/php-cli:latest php/debian/cli
     - name: Scan php-cli image
+      id: scan_php_cli
       uses: anchore/scan-action@master
       with:
         image-reference: "srijanlabs/php-cli:latest"
-        dockerfile-path: "php/cli/Dockerfile"
-        fail-build: true
+        dockerfile-path: "php/debian/cli/Dockerfile"
+        fail-build: false
+        acs-report-enable: true
+
     # php-dev
     - name: Build php-dev image
-      run: docker build -f php/dev/Dockerfile -t srijanlabs/php-dev:latest php/dev
-    - name: Scan php-cli image
+      id: build_php_dev
+      run: docker build -f php/debian/dev/Dockerfile -t srijanlabs/php-dev:latest php/debian/dev
+    - name: Scan php-dev image
+      id: scan_php_dev
       uses: anchore/scan-action@master
       with:
         image-reference: "srijanlabs/php-dev:latest"
-        dockerfile-path: "php/dev/Dockerfile"
-        fail-build: true
+        dockerfile-path: "php/debian/dev/Dockerfile"
+        fail-build: false
+        acs-report-enable: true
+
     # php-fpm
     - name: Build php-fpm image
-      run: docker build -f php/fpm/Dockerfile -t srijanlabs/php-fpm:latest php/fpm
+      id: build_php_fpm
+      run: docker build -f php/debian/fpm/Dockerfile -t srijanlabs/php-fpm:latest php/debian/fpm
     - name: Scan php-fpm image
+      id: scan_php_fpm
       uses: anchore/scan-action@master
       with:
         image-reference: "srijanlabs/php-fpm:latest"
-        dockerfile-path: "php/fpm/Dockerfile"
-        fail-build: true
+        dockerfile-path: "php/debian/fpm/Dockerfile"
+        fail-build: false
+        acs-report-enable: true
+
+    # php-fpm-apache
+    - name: Build php-fpm-apache image
+      id: build_php_fpm_apache
+      run: docker build -f php-fpm-apache/debian/Dockerfile -t srijanlabs/php-fpm-apache:latest php-fpm-apache/debian
+    - name: Scan php-fpm-apache image
+      id: scan_php_fpm_apache
+      uses: anchore/scan-action@master
+      with:
+        image-reference: "srijanlabs/php-fpm-apache:latest"
+        dockerfile-path: "php-fpm-apache/debian/Dockerfile"
+        fail-build: false
+        acs-report-enable: true

--- a/php/debian/cli/Dockerfile
+++ b/php/debian/cli/Dockerfile
@@ -16,9 +16,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-ins
     && chmod +x /usr/local/bin/composer \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PHP_INI_SCAN_DIR=/etc/php/${PHP_VERSION}/cli/conf.d
-COPY conf.d/01_newrelic.ini ${PHP_INI_SCAN_DIR}/01_newrelic.ini
-COPY conf.d/50_overrides.ini ${PHP_INI_SCAN_DIR}/50_overrides.ini
+ENV PHP_INI_DIR=/etc/php/${PHP_VERSION}/cli/conf.d
+COPY conf.d/50_overrides.ini ${PHP_INI_DIR}/50_overrides.ini
+COPY conf.d/01_newrelic.ini ${PHP_INI_DIR}/01_newrelic.ini
 
 USER continua
 

--- a/php/debian/cli/conf.d/01_newrelic.ini
+++ b/php/debian/cli/conf.d/01_newrelic.ini
@@ -7,7 +7,7 @@
 ; extension directory changing if you change PHP installations or versions.
 ; If you do not use an absolute path then the file must be installed in the
 ; active configuration's extension directory.
-extension = "newrelic.so"
+#extension = "newrelic.so"
 
 [newrelic]
 ; Setting: newrelic.enabled
@@ -88,9 +88,9 @@ newrelic.logfile = "/var/log/newrelic/php_agent.log"
 ;          UI security setting. If the two settings do not match, then no data
 ;          will be collected.
 ;
-;          IMPORTANT: This setting is not compatible with 
+;          IMPORTANT: This setting is not compatible with
 ;          newrelic.security_policies_token. Only one may be set. If both are
-;          set an error will be thrown and the agent will not connect. 
+;          set an error will be thrown and the agent will not connect.
 ;
 ;newrelic.high_security = false
 
@@ -853,6 +853,6 @@ newrelic.daemon.logfile = /dev/null
 ;
 ;          IMPORTANT: This setting is not compatible with newrelic.high_security.
 ;          Only one may be set. If both are set an error will be thrown and the
-;          agent will not connect. 
+;          agent will not connect.
 ;
 ;newrelic.security_policies_token = ""

--- a/php/debian/dev/Dockerfile
+++ b/php/debian/dev/Dockerfile
@@ -19,8 +19,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
 # @TODO: Fix the concept of PHP_INI_SCAN_DIR.
-COPY conf.d/01_blackfire.ini ${PHP_INI_SCAN_DIR}/01_blackfire.ini
-COPY conf.d/50_dev.ini ${PHP_INI_SCAN_DIR}/50_dev.ini
-COPY conf.d/01_xdebug.ini ${PHP_INI_SCAN_DIR}/01_xdebug.ini
+COPY conf.d/01_blackfire.ini ${PHP_INI_DIR}/01_blackfire.ini
+COPY conf.d/50_dev.ini ${PHP_INI_DIR}/50_dev.ini
+COPY conf.d/01_xdebug.ini ${PHP_INI_DIR}/01_xdebug.ini
 
 USER continua

--- a/php/debian/dev/conf.d/01_xdebug.ini
+++ b/php/debian/dev/conf.d/01_xdebug.ini
@@ -1,4 +1,4 @@
-zend_extension=xdebug.so
+#zend_extension=xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_autostart=1
 xdebug.remote_connect_back=0

--- a/php/debian/fpm/Dockerfile
+++ b/php/debian/fpm/Dockerfile
@@ -12,12 +12,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && ln -sf /usr/sbin/php-fpm${PHP_VERSION} /usr/sbin/php-fpm \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PHP_INI_SCAN_DIR=/etc/php/${PHP_VERSION}/fpm/conf.d
+ENV PHP_INI_DIR=/etc/php/${PHP_VERSION}/fpm/conf.d
 
 COPY php-fpm.conf /etc/php/${PHP_VERSION}/fpm/php-fpm.conf
-COPY conf.d/50_fpm.ini ${PHP_INI_SCAN_DIR}/50_fpm.ini
-COPY conf.d/01_newrelic.ini ${PHP_INI_SCAN_DIR}/01_newrelic.ini
-COPY conf.d/50_overrides.ini ${PHP_INI_SCAN_DIR}/50_overrides.ini
+COPY conf.d/50_fpm.ini ${PHP_INI_DIR}/50_fpm.ini
+COPY conf.d/01_newrelic.ini ${PHP_INI_DIR}/01_newrelic.ini
+COPY conf.d/50_overrides.ini ${PHP_INI_DIR}/50_overrides.ini
 
 EXPOSE 9000
 

--- a/php/debian/fpm/conf.d/01_newrelic.ini
+++ b/php/debian/fpm/conf.d/01_newrelic.ini
@@ -88,9 +88,9 @@ newrelic.logfile = "/var/log/newrelic/php_agent.log"
 ;          UI security setting. If the two settings do not match, then no data
 ;          will be collected.
 ;
-;          IMPORTANT: This setting is not compatible with 
+;          IMPORTANT: This setting is not compatible with
 ;          newrelic.security_policies_token. Only one may be set. If both are
-;          set an error will be thrown and the agent will not connect. 
+;          set an error will be thrown and the agent will not connect.
 ;
 ;newrelic.high_security = false
 
@@ -853,6 +853,6 @@ newrelic.daemon.logfile = /dev/null
 ;
 ;          IMPORTANT: This setting is not compatible with newrelic.high_security.
 ;          Only one may be set. If both are set an error will be thrown and the
-;          agent will not connect. 
+;          agent will not connect.
 ;
 ;newrelic.security_policies_token = ""


### PR DESCRIPTION
PHP_INI_SCAN_DIR variable is creating a problem in the cli image so I renamed this variable to PHP_INI_DIR and now all the containers are working fine on my local.